### PR TITLE
generate an atom feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+atom.xml

--- a/mailer/gleam.toml
+++ b/mailer/gleam.toml
@@ -6,6 +6,8 @@ version = "1.0.0"
 gleam_stdlib = "~> 0.34 or ~> 1.0"
 lustre = "~> 4.0"
 simplifile = "~> 1.5"
+xmleam = ">= 1.1.4 and < 2.0.0"
+birl = ">= 1.6.1 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/mailer/gleam.toml
+++ b/mailer/gleam.toml
@@ -6,7 +6,7 @@ version = "1.0.0"
 gleam_stdlib = "~> 0.34 or ~> 1.0"
 lustre = "~> 4.0"
 simplifile = "~> 1.5"
-xmleam = ">= 1.1.4 and < 2.0.0"
+xmleam = ">= 1.1.5 and < 2.0.0"
 birl = ">= 1.6.1 and < 2.0.0"
 
 [dev-dependencies]

--- a/mailer/manifest.toml
+++ b/mailer/manifest.toml
@@ -2,18 +2,23 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "birl", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "976CFF85D34D50F7775896615A71745FBE0C325E50399787088F941B539A0497" },
   { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
   { name = "gleam_json", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9063D14D25406326C0255BDA0021541E797D8A7A12573D849462CAFED459F6EB" },
   { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
   { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
   { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
   { name = "lustre", version = "4.2.4", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib"], otp_app = "lustre", source = "hex", outer_checksum = "09B94E1380CBC400DCD594B36A845E5CB2E143DF89E95460B2CA59E44499CAC9" },
+  { name = "ranger", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "1566C272B1D141B3BBA38B25CB761EF56E312E79EC0E2DFD4D3C19FB0CC1F98C" },
   { name = "simplifile", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "EB9AA8E65E5C1E3E0FDCFC81BC363FD433CB122D7D062750FFDF24DE4AC40116" },
   { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
+  { name = "xmleam", version = "1.1.4", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "xmleam", source = "hex", outer_checksum = "A747975444CE3343B6728AB217A1C44888A38060DFA41CA0C0B41D3E06417981" },
 ]
 
 [requirements]
+birl = { version = ">= 1.6.1 and < 2.0.0" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }
 lustre = { version = "~> 4.0" }
 simplifile = { version = "~> 1.5" }
+xmleam = { version = ">= 1.1.4 and < 2.0.0" }

--- a/mailer/manifest.toml
+++ b/mailer/manifest.toml
@@ -12,7 +12,7 @@ packages = [
   { name = "ranger", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "1566C272B1D141B3BBA38B25CB761EF56E312E79EC0E2DFD4D3C19FB0CC1F98C" },
   { name = "simplifile", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "EB9AA8E65E5C1E3E0FDCFC81BC363FD433CB122D7D062750FFDF24DE4AC40116" },
   { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
-  { name = "xmleam", version = "1.1.4", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "xmleam", source = "hex", outer_checksum = "A747975444CE3343B6728AB217A1C44888A38060DFA41CA0C0B41D3E06417981" },
+  { name = "xmleam", version = "1.1.5", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "xmleam", source = "hex", outer_checksum = "4D69B1074781E9EE335A9C0EBC56C228890940F80E18D6A1B024C2C97BFF52AB" },
 ]
 
 [requirements]
@@ -21,4 +21,4 @@ gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }
 lustre = { version = "~> 4.0" }
 simplifile = { version = "~> 1.5" }
-xmleam = { version = ">= 1.1.4 and < 2.0.0" }
+xmleam = { version = ">= 1.1.5 and < 2.0.0" }

--- a/mailer/src/feed.gleam
+++ b/mailer/src/feed.gleam
@@ -1,0 +1,97 @@
+import birl
+import gleam/int
+import gleam/io
+import gleam/list
+import gleam/result
+import gleam/string
+import lustre/element
+import lustre/element/html
+import mailer/content
+import mailer/template
+import simplifile
+import xmleam/xml_builder.{Opt, block_tag, end_xml, new, option_block_tag, tag}
+
+type Issue {
+  Issue(id: Int, published: birl.Time, summary: String)
+}
+
+fn render_issues() -> List(Issue) {
+  list.reverse(content.issues)
+  |> list.index_map(fn(issue, index) {
+    let number = index + 1
+    let #(date, _, _) = issue
+    // assert is ok here since all issues (should) have a valid date associated with them
+    let assert Ok(time) = birl.from_naive(date)
+    Issue(
+      id: number,
+      published: time,
+      summary: html.div([], [template.content(issue, number)])
+        |> element.to_string,
+    )
+  })
+}
+
+// for reference see https://validator.w3.org/feed/docs/atom.html
+fn generate_rss_feed(entries: List(Issue)) -> Result(String, Nil) {
+  xml_builder.new_document()
+  |> option_block_tag("feed", [Opt("xmlns", "http://www.w3.org/2005/Atom")], {
+    let document =
+      new()
+      // these are required
+      |> tag("id", "https://gleamweekly.com/")
+      |> tag("title", "Gleam weekly")
+      |> tag(
+        "updated",
+        birl.now()
+          |> birl.to_http,
+      )
+      // these are recommended
+      |> tag("link", "https://gleamweekly.com/")
+      |> block_tag(
+        "author",
+        new()
+          |> tag("name", "Peter Saxton"),
+      )
+      // everything below is optional
+      |> tag("description", "Gleam is so hot right now")
+
+    use doc, issue <- list.fold(entries, document)
+    let link =
+      "https://gleamweekly.com/issues/" <> int.to_string(issue.id) <> "/"
+
+    // updated + published could use some polish
+    doc
+    |> block_tag("entry", {
+      new()
+      // these are required
+      |> tag("id", link)
+      |> tag("title", "Gleam weekly #" <> int.to_string(issue.id))
+      |> tag("updated", birl.to_http(issue.published))
+      // these are optional
+      |> tag("link", link)
+      |> tag("summary", "<![CDATA[" <> issue.summary <> "]]>")
+      |> tag("published", birl.to_http(issue.published))
+    })
+  })
+  |> end_xml
+  |> result.nil_error
+}
+
+pub fn build(root) {
+  let contents: List(Issue) = render_issues()
+
+  use feed <- result.try(generate_rss_feed(contents))
+  let path = string.replace(root, "/mailer", "/atom.xml")
+  use _ <- result.try(
+    simplifile.write(path, feed)
+    |> result.nil_error,
+  )
+
+  io.println("Successfully wrote atom feed to " <> path)
+  |> Ok
+}
+
+pub fn main() {
+  let assert Ok(cwd) = simplifile.current_directory()
+  build(cwd)
+}

--- a/mailer/src/mailer.gleam
+++ b/mailer/src/mailer.gleam
@@ -1,5 +1,7 @@
+import feed
 import gleam/bit_array
 import gleam/int
+import gleam/io
 import gleam/list
 import gleam/result.{try}
 import gleam/string
@@ -10,7 +12,8 @@ import simplifile
 
 pub fn main() {
   let assert Ok(cwd) = simplifile.current_directory()
-  build(cwd)
+  let _ = build(cwd)
+  let _ = feed.build(cwd)
 }
 
 pub fn build(root) {
@@ -25,7 +28,13 @@ pub fn build(root) {
     })
 
   let path = string.replace(root, "/mailer", "/email.html")
-  let assert Ok(_) = simplifile.write(path, email(root))
+  use _ <- result.try(
+    simplifile.write(path, email(root))
+    |> result.nil_error,
+  )
+
+  io.println("Successfully wrote email to " <> path)
+  |> Ok
 }
 
 pub fn current_issue_number() {

--- a/mailer/src/mailer/content.gleam
+++ b/mailer/src/mailer/content.gleam
@@ -19,6 +19,7 @@ pub type Tag {
 // https://discord.com/channels/768594524158427167/1047101890707603547/threads/1245790643452776511
 pub const issues = [
   #(
+    "2024-05-30",
     [
       News(
         "Gleam 1.2.0 release - Fault tolerant Gleam",
@@ -60,6 +61,7 @@ pub const issues = [
     ],
   ),
   #(
+    "2024-05-23",
     [
       News(
         "Gleam on NPM",
@@ -96,6 +98,7 @@ pub const issues = [
     ],
   ),
   #(
+    "2024-05-20",
     [
       News(
         "A Practical Use Case for Function Capture in Gleam",
@@ -127,6 +130,7 @@ pub const issues = [
     ],
   ),
   #(
+    "2024-05-09",
     [
       News(
         "Code BEAM Lite Stockholm",
@@ -163,6 +167,7 @@ pub const issues = [
     ],
   ),
   #(
+    "2024-05-02",
     [
       News(
         "Run Gleam run",
@@ -204,6 +209,7 @@ pub const issues = [
     ],
   ),
   #(
+    "2024-05-01",
     [
       News(
         "Scriptorium - A simple blog generator",
@@ -245,6 +251,7 @@ pub const issues = [
     ],
   ),
   #(
+    "2024-04-18",
     [
       News(
         "Gleam version v1.1",
@@ -291,6 +298,7 @@ pub const issues = [
     ],
   ),
   #(
+    "2024-04-12",
     [
       News(
         "Building the same app in Gleam and JavaScript",
@@ -332,6 +340,7 @@ pub const issues = [
     ],
   ),
   #(
+    "2024-04-04",
     [
       News(
         "Supervisors (3/3)",
@@ -388,6 +397,7 @@ pub const issues = [
     ],
   ),
   #(
+    "2024-03-28",
     [
       News(
         "Monitoring Processes",
@@ -445,6 +455,7 @@ pub const issues = [
     ],
   ),
   #(
+    "2024-03-23",
     [
       News(
         "Gleam version 1",

--- a/mailer/src/mailer/template.gleam
+++ b/mailer/src/mailer/template.gleam
@@ -1,9 +1,9 @@
 import gleam/int
 import gleam/list
 import gleam/string
+import lustre/attribute as a
 import lustre/element.{text}
 import lustre/element/html as h
-import lustre/attribute as a
 import mailer/content.{Also, News}
 
 const faff_pink = "#ffaff3"
@@ -25,7 +25,7 @@ const charcoal = "#2f2f2f"
 const blacker = "#151515"
 
 pub fn content(issue, number) {
-  let #(items, also) = issue
+  let #(_date, items, also) = issue
   let issue_url =
     string.concat(["https://gleamweekly.com/issues/", int.to_string(number)])
   h.div(


### PR DESCRIPTION
Building the email now also generates an atom feed. This does however require adding a date to all issues. For existing issues I determined the publishing date from the git history.

I tested the generated feed with my home-cooked feed reader so it would be best if you test it again before merging.